### PR TITLE
Convenient End-User Debugging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,46 +2,54 @@
 name: Release Creation
 
 on:
-  release:
-    types: [published]
+   release:
+      types: [published]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+   build:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+              node-version: 22
+              cache: "npm"
 
-      # Substitute the Manifest and Download URLs in the `module.json`.
-      - name: Substitute Manifest and Download Links For Versioned Ones
-        id: sub_manifest_link_version
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: 'module.json'
-        env:
-          version: ${{github.event.release.tag_name}}
-          url: https://github.com/${{github.repository}}
-          manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
-          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+         - name: Extract version from tag without the v
+           id: get-version
+           run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      # Install packages.
-      - run: npm install
+         - name: Substitute Manifest and Download Links For Versioned Ones
+           id: sub_manifest_link_version
+           uses: microsoft/variable-substitution@v1
+           with:
+              files: "module.json"
+           env:
+              version: ${{ steps.get-version.outputs.v }}
+              url: https://github.com/${{github.repository}}
+              manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+              download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
-      # Build distribution.
-      - run: npm run build-dist
+         - name: Install packages
+           run: npm ci
 
-      # Create a zip file with all files required by the module to add to the release.
-      - run: zip -r ./module.zip module.json dist/ lang/ packs/ LICENSE AUTHORS
+         - name: Build distribution
+           run: npm run build
 
-      # Create a release for this specific version.
-      - name: Update Release with Files
-        id: create_version_release
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true # Set this to false if you want to prevent updating existing releases.
-          name: ${{ github.event.release.name }}
-          draft: false
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: './module.json, ./module.zip'
-          tag: ${{ github.event.release.tag_name }}
-          body: ${{ github.event.release.body }}
+         # Create a zip file with all files required by the module to add to the release.
+         - name: Bundle into ZIP file
+           run: zip -r ./module.zip module.json dist/ lang/ packs/ LICENSE
+
+         # Create a release for this specific version.
+         - name: Update Release with Files
+           id: create_version_release
+           uses: ncipollo/release-action@v1
+           with:
+              allowUpdates: true # Set this to false if you want to prevent updating existing releases.
+              name: ${{ github.event.release.name }}
+              tag: ${{ github.event.release.tag_name }}
+              body: ${{ github.event.release.body }}
+              artifacts: "./module.json, ./module.zip"
+              omitDraftDuringUpdate: true
+              omitPrereleaseDuringUpdate: true
+

--- a/module.json
+++ b/module.json
@@ -14,10 +14,10 @@
     "verified": "12"
   },
   "esmodules": [
-    "dist/index.js"
+    "dist/template-svelte-ts.js"
   ],
   "styles": [
-    "dist/style.css"
+    "dist/template-svelte-ts.css"
   ],
   "flags": {
     "hotReload": {

--- a/module.json
+++ b/module.json
@@ -1,8 +1,7 @@
 {
-  "name": "template-svelte-ts",
+  "id": "template-svelte-ts",
   "title": "Template Svelte (TS)",
   "description": "Provides a bare bones Typescript template repo to get set up with using the TyphonJS Runtime Library and Svelte.",
-  "author": "Michael Leahy (TyphonJS) - MLeahy#4299",
   "authors": [
     {
       "name": "Michael Leahy (TyphonJS) - MLeahy#4299",
@@ -11,19 +10,23 @@
   ],
   "version": "0.0.0",
   "compatibility": {
-    "minimum": "10",
+    "minimum": "12",
     "verified": "12"
   },
   "esmodules": [
-    "index.js"
+    "dist/index.js"
   ],
   "styles": [
-    "style.css"
+    "dist/style.css"
   ],
   "flags": {
     "hotReload": {
-      "extensions": ["json"],
-      "paths": ["lang"]
+      "extensions": [
+        "json"
+      ],
+      "paths": [
+        "lang"
+      ]
     }
   },
   "languages": [
@@ -33,13 +36,13 @@
       "path": "lang/en.json"
     }
   ],
-  "socket": false,
   "url": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts",
   "readme": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts/blob/master/README.md",
   "bugs": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts/issues",
   "changelog": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts/releases/latest/",
   "manifest": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts/releases/latest/download/module.json",
   "download": "https://github.com/typhonjs-fvtt-demo/template-svelte-ts/releases/download/0.0.0/module.zip",
+  "socket": false,
   "protected": false,
   "coreTranslation": false,
   "library": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "svelte": "^4.2.19"
       },
       "devDependencies": {
+        "@types/node": "^22.10.2",
         "foundry-pf2e": "github:7H3LaughingMan/foundry-pf2e",
         "typescript": "^5.7.2"
       }

--- a/package.json
+++ b/package.json
@@ -18,10 +18,14 @@
     "svelte": "^4.2.19"
   },
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "foundry-pf2e": "github:7H3LaughingMan/foundry-pf2e",
     "typescript": "^5.7.2"
   },
-  "browserslist": [">5%", "not IE 11"],
+  "browserslist": [
+    ">5%",
+    "not IE 11"
+  ],
   "scripts": {
     "build": "vite build",
     "dev": "vite"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,9 +4,14 @@ import {
    postcssConfig,
    terserConfig
 }                             from '@typhonjs-fvtt/runtime/rollup';
+import moduleJSON             from './module.json' with { type: 'json' };
 import { sveltePreprocess }   from 'svelte-preprocess';
 import { defineConfig }       from 'vite';
-import moduleJSON             from './module.json' with { type: 'json' };
+import {
+   existsSync,
+   mkdir,
+   writeFileSync
+}                             from 'fs';
 
 // ATTENTION!
 // Please modify the below s_SVELTE_HASH_ID variable appropriately.
@@ -64,13 +69,13 @@ export default defineConfig(({ mode }) =>
          open: '/game',
          proxy: {
             // Serves static files from main Foundry server.
-            [`^(/${s_PACKAGE_ID}/(assets|lang|packs|dist/style.css))`]: 'http://localhost:30000',
+            [`^(/${s_PACKAGE_ID}/(assets|lang|packs|dist/${moduleJSON.id}.css))`]: 'http://localhost:30000',
 
             // All other paths besides package ID path are served from main Foundry server.
             [`^(?!/${s_PACKAGE_ID}/)`]: 'http://localhost:30000',
 
-            // Rewrite incoming `index.js` request from Foundry to the dev server `index.ts`.
-            [`/${s_PACKAGE_ID}/dist/index.js`]: {
+            // Rewrite incoming `module-id.js` request from Foundry to the dev server `index.ts`.
+            [`/${s_PACKAGE_ID}/dist/${moduleJSON.id}.js`]: {
                target: `http://localhost:30001/${s_PACKAGE_ID}/dist`,
                rewrite: () => '/index.ts',
             },
@@ -90,8 +95,15 @@ export default defineConfig(({ mode }) =>
          lib: {
             entry: './index.ts',
             formats: ['es'],
-            fileName: 'index'
-         }
+            fileName: moduleJSON.id
+         },
+         rollupOptions: {
+            output: {
+               // Rewrite the default style.css to a more recognizable file name.
+               assetFileNames: assetInfo =>
+                  assetInfo.name === 'style.css' ? `${moduleJSON.id}.css` : assetInfo.name as string,
+            },
+         },
       },
 
       // Necessary when using the dev server for top-level await usage inside TRL.
@@ -105,7 +117,25 @@ export default defineConfig(({ mode }) =>
          svelte({
             compilerOptions,
             preprocess: sveltePreprocess()
-         })
+         }),
+         {
+            // A plugin to create dist/ files to make Foundry not complaing about missing files
+            // Without it, you and any contributor would have to run the build command first.
+            name: 'create-dist-files',
+            apply: 'serve',
+            buildStart() {
+               if (!existsSync('dist')) {
+                  mkdir('dist', (err) => {
+                     if (err) throw err;
+                  });
+               }
+
+               const files = [...moduleJSON.esmodules, ...moduleJSON.styles];
+               for (const name of files) {
+                  writeFileSync(name, '', { flag: 'a' });
+               }
+            },
+         },
       ]
    };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,18 +3,18 @@ import { svelte }             from '@sveltejs/vite-plugin-svelte';
 
 import {
    postcssConfig,
-   terserConfig }             from '@typhonjs-fvtt/runtime/rollup';
+   terserConfig
+}                             from '@typhonjs-fvtt/runtime/rollup';
 
 import { sveltePreprocess }   from 'svelte-preprocess';
 
 import { defineConfig }       from 'vite';
+import moduleJSON             from './module.json' with { type: 'json' };
 
 // ATTENTION!
-// Please modify the below variables: s_PACKAGE_ID and s_SVELTE_HASH_ID appropriately.
+// Please modify the below s_SVELTE_HASH_ID variable appropriately.
 
-// For convenience, you just need to modify the package ID below as it is used to fill in default proxy settings for
-// the dev server.
-const s_PACKAGE_ID = 'modules/template-svelte-ts';
+const s_PACKAGE_ID = `modules/${moduleJSON.id}`;
 
 // A short additional string to add to Svelte CSS hash values to make yours unique. This reduces the amount of
 // duplicated framework CSS overlap between many TRL packages enabled on Foundry VTT at the same time. 'tst' is chosen
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) =>
 
    return {
       root: 'src/',                 // Source location / esbuild root.
-      base: `/${s_PACKAGE_ID}/`,    // Base module path that 30001 / served dev directory.
+      base: `/${s_PACKAGE_ID}/dist`,    // Base module path that 30001 / served dev directory.
       publicDir: false,             // No public resources to copy.
       cacheDir: '../.vite-cache',   // Relative from root directory.
 
@@ -73,8 +73,8 @@ export default defineConfig(({ mode }) =>
             [`^(?!/${s_PACKAGE_ID}/)`]: 'http://localhost:30000',
 
             // Rewrite incoming `index.js` request from Foundry to the dev server `index.ts`.
-            [`/${s_PACKAGE_ID}/index.js`]: {
-               target: `http://localhost:30001/${s_PACKAGE_ID}/`,
+            [`/${s_PACKAGE_ID}/dist/index.js`]: {
+               target: `http://localhost:30001/${s_PACKAGE_ID}/dist`,
                rewrite: () => '/index.ts',
             },
 
@@ -83,7 +83,7 @@ export default defineConfig(({ mode }) =>
          }
       },
       build: {
-         outDir: __dirname,
+         outDir: '../dist',
          emptyOutDir: false,
          sourcemap: s_SOURCEMAPS,
          brotliSize: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,7 +64,7 @@ export default defineConfig(({ mode }) =>
          open: '/game',
          proxy: {
             // Serves static files from main Foundry server.
-            [`^(/${s_PACKAGE_ID}/(assets|lang|packs|style.css))`]: 'http://localhost:30000',
+            [`^(/${s_PACKAGE_ID}/(assets|lang|packs|dist/style.css))`]: 'http://localhost:30000',
 
             // All other paths besides package ID path are served from main Foundry server.
             [`^(?!/${s_PACKAGE_ID}/)`]: 'http://localhost:30000',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,10 @@
 /* eslint-env node */
 import { svelte }             from '@sveltejs/vite-plugin-svelte';
-
 import {
    postcssConfig,
    terserConfig
 }                             from '@typhonjs-fvtt/runtime/rollup';
-
 import { sveltePreprocess }   from 'svelte-preprocess';
-
 import { defineConfig }       from 'vite';
 import moduleJSON             from './module.json' with { type: 'json' };
 
@@ -35,10 +32,10 @@ export default defineConfig(({ mode }) =>
    } : {};
 
    return {
-      root: 'src/',                 // Source location / esbuild root.
-      base: `/${s_PACKAGE_ID}/dist`,    // Base module path that 30001 / served dev directory.
-      publicDir: false,             // No public resources to copy.
-      cacheDir: '../.vite-cache',   // Relative from root directory.
+      root: 'src/',                  // Source location / esbuild root.
+      base: `/${s_PACKAGE_ID}/dist`, // Base module path that 30001 / served dev directory.
+      publicDir: false,              // No public resources to copy.
+      cacheDir: '../.vite-cache',    // Relative from root directory.
 
       resolve: {
          conditions: ['browser', 'import']


### PR DESCRIPTION
> Made into a separate PR from #1 as this is mainly an improvement than a fix. 

Adds renaming of output `style` and `index` files to be the name of the module, making identification of any errors immediately obvious.
<img width="149" alt="Code_AnH4CVxav0" src="https://github.com/user-attachments/assets/3043fe0a-a8b5-40c4-b795-231351d42b50" />

Also added a short plugin that makes going from `npm i` to `npm run dev` possible without needing an intermediate `npm run build` by generating dummy `dist/` files to make Foundry not complain about missing files.